### PR TITLE
Use v1.1 in README.md example action file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
   sync_reviewers_assignees:
     runs-on: ubuntu-latest
     steps:
-    - uses: rubeus90/auto-sync-reviewer-assignee@v1.0
+    - uses: rubeus90/auto-sync-reviewer-assignee@v1.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         exclude: 'user1,user2'


### PR DESCRIPTION
Thanks for a great Action, very useful.

I used the example workflow in our repos and was hit by the bug re. adding the PR author as reviewer which was fixed in v1.1.
So would be great to have the example updated to the latest version, so others don't run into this issue :-)